### PR TITLE
remove unused files from web_absolute

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -57,6 +57,10 @@ mw.addonManager.setWebExports(__name__, regex)
 def update_css():
     # on startup: combine template files with config and write into webexports folder
     change_copy = [os.path.basename(f) for f in os.listdir(source_absolute) if f.endswith(".css")]
+    to_delete = [os.path.basename(f) for f in os.listdir(web_absolute) if f.endswith(".css") and f not in change_copy]
+    for f in to_delete:
+        os.remove(os.path.join(web_absolute, f))
+ 
     for f in change_copy:
         with open(os.path.join(source_absolute, f)) as FO:
             filecontent = FO.read()


### PR DESCRIPTION
Fixes bug mentioned in #49

This bug occurs when coming from 2.1.55 to 2.1.54 because the add-on creates some css files in 2.1.55, which would not have been created in 2.1.54 but is not deleted when running the add-on in 2.1.54.